### PR TITLE
Add import readr to documentation

### DIFF
--- a/R/load_data.R
+++ b/R/load_data.R
@@ -1,6 +1,8 @@
 #' load positive COVID cases
 #'
 #' Cargal la base de datos de casos confirmados desde la página de datos abiertos
+#' 
+#' @import readr
 #'
 #' @return data_frame
 #' @export


### PR DESCRIPTION
Esta línea invocará al paquete `readr` y evitará errores al correr `library(covidPeru); da_positivos()` por el uso de la función `locale()`

reprex:

```r
library(covidPeru)
da_positivos()
#> Error in locale(encoding = "latin1") : 
#>   no se pudo encontrar la función "locale"
```

Lo mismo se pueden intentar en las otras documentaciones

Otra opción es anteponer un `readr::` a todos los usos de la función `locale `